### PR TITLE
Add go 1.16.x and go 1.17.x to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go


### PR DESCRIPTION
In the actions, this adds the 1.16 and 1.17 versions.

Signed-off-by: Brad P. Crochet <brad@redhat.com>