### PR TITLE
Fix panic in scanning rows when query fails

### DIFF
--- a/pkg/sqlite3/sqlite3.go
+++ b/pkg/sqlite3/sqlite3.go
@@ -64,17 +64,19 @@ func (db *SQLite3) Read() <-chan dbi.Entry {
 			}
 		}
 
-		for rows.Next() {
-			var blob string
-			if err := rows.Scan(&blob); err != nil {
-				entries <- dbi.Entry{
-					Err: xerrors.Errorf("failed to Scan Row: %w", err),
+		if rows != nil { // nil if db.Query failed
+			for rows.Next() {
+				var blob string
+				if err := rows.Scan(&blob); err != nil {
+					entries <- dbi.Entry{
+						Err: xerrors.Errorf("failed to Scan Row: %w", err),
+					}
 				}
-			}
 
-			entries <- dbi.Entry{
-				Value: []byte(blob),
-				Err:   nil,
+				entries <- dbi.Entry{
+					Value: []byte(blob),
+					Err:   nil,
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
Fixing a bug in the sqlite RPMDB implementation where reading from Packages (`SELECT blob FROM Packages`) failing would cause a panic when calling `rows.Next()` due to `rows` being nil.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>